### PR TITLE
Make better use of Amp streams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor

--- a/src/Bufferer/BuffererInterface.php
+++ b/src/Bufferer/BuffererInterface.php
@@ -9,6 +9,7 @@ interface BuffererInterface
     public function __invoke();
     public function getFilePath(): string;
     public function isBuffering(): bool;
+    public function waitForWrite(): Promise;
     public function getMimeType(): Promise;
     public function getCurrentProgress(): int;
 }

--- a/src/Bufferer/PipeBufferer.php
+++ b/src/Bufferer/PipeBufferer.php
@@ -22,9 +22,6 @@ class PipeBufferer implements BuffererInterface
 
     private $deferred;
 
-    /**
-     * @param resource $inputStream
-     */
     public function __construct(
         LoggerInterface $logger,
         InputStream $inputStream,
@@ -46,7 +43,7 @@ class PipeBufferer implements BuffererInterface
 
         $bytesDownloaded = 0;
         while (null !== $chunk = yield $this->inputStream->read()) {
-            yield $promise = $outputStream->write($chunk);
+            $promise = $outputStream->write($chunk);
 
             if ($this->deferred) {
                 $deferred = $this->deferred;
@@ -61,6 +58,8 @@ class PipeBufferer implements BuffererInterface
             }
 
             $this->progressBar->setProgress($bytesDownloaded += strlen($chunk));
+
+            yield $promise;
         }
 
         if ($this->deferred) {

--- a/src/Bufferer/ResolvedBufferer.php
+++ b/src/Bufferer/ResolvedBufferer.php
@@ -31,6 +31,11 @@ class ResolvedBufferer implements BuffererInterface
         return false;
     }
 
+    public function waitForWrite(): Promise
+    {
+        return new Success(0);
+    }
+
     public function getMimeType(): Promise
     {
         return new Success($this->mimeType);

--- a/src/Command.php
+++ b/src/Command.php
@@ -2,8 +2,6 @@
 
 namespace Ostrolucky\Stdinho;
 
-use Amp\ByteStream\ResourceInputStream;
-use Amp\ByteStream\ResourceOutputStream;
 use Ostrolucky\Stdinho\Bufferer\PipeBufferer;
 use Ostrolucky\Stdinho\Bufferer\ResolvedBufferer;
 use Symfony\Component\Console\Helper\DescriptorHelper;
@@ -52,7 +50,7 @@ class Command extends \Symfony\Component\Console\Command\Command
         $logger = new ConsoleLogger($firstSection = $output->section());
 
         $bufferer = $hasStdin ?
-            new PipeBufferer($logger, $stdin, $filePath, $output->section()) :
+            new PipeBufferer($logger, \Amp\ByteStream\getStdin(), $filePath, $output->section()) :
             new ResolvedBufferer($filePath)
         ;
 


### PR DESCRIPTION
Fixed reading from a file that is being simultaneously written to by the same process. The read loop in `Responder` would busy wait when EOF was reached until another write was made from the bufferer. As you found in amphp/byte-stream#47, replacing this with blocking functions would block the entire process. Streaming a file no longer results in 100% CPU. Performance between `BlockingDriver` and `ParallelDriver` from amphp/file is comparable on my computer piping data from `/dev/urandom`.

I also tossed in a few other suggested changes. 😃